### PR TITLE
Add watcher for .standard_todo.yml

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -279,6 +279,7 @@ function buildLanguageClientOptions (): LanguageClientOptions {
     synchronize: {
       fileEvents: [
         workspace.createFileSystemWatcher('**/.standard.yml'),
+        workspace.createFileSystemWatcher('**/.standard_todo.yml'),
         workspace.createFileSystemWatcher('**/Gemfile.lock')
       ]
     },


### PR DESCRIPTION
I recently opened #16 that talks about how it would be nice to restart the language server when `.standard_todo.yml` changes. I believe the additional line added here will accomplish that if that is desired behavior.