### PR TITLE
Add `standardRuby.additionalLanguages` for linting non-Ruby files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   ],
   "activationEvents": [
     "onLanguage:ruby",
-    "workspaceContains:Gemfile.lock"
+    "workspaceContains:Gemfile.lock",
+    "workspaceContains:**/.standard.yml"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -102,6 +103,15 @@
             "type": "string",
             "default": "",
             "markdownDescription": "Absolute path to standardrb executable. Overrides default search order and, if missing, will not run Standard via Bundler or a `standardrb` executable on your PATH.\n\nSupports variables `${userHome}`, `${pathSeparator}`, and `${cwd}`"
+          },
+          "standardRuby.additionalLanguages": {
+            "order": 4,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "markdownDescription": "Additional [VS Code language identifiers](https://code.visualstudio.com/docs/languages/identifiers) to send to the Standard Ruby language server, in addition to `ruby` and `Gemfile`.\n\nUse this to lint non-Ruby files that a custom RuboCop cop handles via `on_other_file` — for example `[\"yaml\"]` for a plugin that validates `data/**/*.yml`, or `[\"erb\"]` for an ERB linter.\n\n**Important:** Standard's built-in cops must be excluded for these files in your project config (e.g. `Lint`/`Layout`/… `Exclude: \"**/*.yml\"`), otherwise every file of that type will be parsed as Ruby and report `Lint/Syntax` errors."
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,8 +85,12 @@ function getConfig<T> (key: string): T | undefined {
   return workspace.getConfiguration('standardRuby').get<T>(key)
 }
 
+function additionalLanguages (): string[] {
+  return getConfig<string[]>('additionalLanguages') ?? []
+}
+
 function supportedLanguage (languageId: string): boolean {
-  return languageId === 'ruby' || languageId === 'gemfile'
+  return languageId === 'ruby' || languageId === 'gemfile' || additionalLanguages().includes(languageId)
 }
 
 function registerCommands (): Disposable[] {
@@ -267,6 +271,7 @@ function buildLanguageClientOptions (): LanguageClientOptions {
   return {
     documentSelector: [
       { scheme: 'file', language: 'ruby' },
+      ...additionalLanguages().map((language) => ({ scheme: 'file', language })),
       { scheme: 'file', pattern: '**/Gemfile' }
     ],
     diagnosticCollectionName: 'standardRuby',


### PR DESCRIPTION
The extension only forwarded `ruby` and `Gemfile` documents to the Standard language server, so custom RuboCop cops that lint other file types (a YAML data validator, an ERB linter, ...) never received their files.

This pull request adds a new `standardRuby.additionalLanguages` setting, an array of VS Code language identifiers that extends both the document selector and the supported-language check. It defaults to `[]`, so nothing changes unless a project opts in; e.g. `["yaml"]` routes `.yml`/`.yaml` to the server.

<img width="2516" height="1894" alt="CleanShot 2026-07-06 at 03 12 23@2x" src="https://github.com/user-attachments/assets/15b54ccc-0509-4e7d-ba2e-b03262da34ff" />

This was inspired by both the `rubocop-herb` plugin I'm working on and more recently, this pull request in RubyEvents (https://github.com/rubyevents/rubyevents/pull/1879) where we wanted to use the existing RuboCop/Lint Roller architecture to surface offenses from our custom Validator directly in the Editor:

<img width="1802" height="874" alt="image" src="https://github.com/user-attachments/assets/cd0fd77b-d69a-45f6-84dc-e93667700b5b" />
